### PR TITLE
one more test

### DIFF
--- a/tokens_test.py
+++ b/tokens_test.py
@@ -17,6 +17,10 @@ class AccessTokensTest(unittest.TestCase):
         print obj2
         self.assertNotEqual(obj, obj2)
 
+        obj3 = tokens.AccessToken()
+        obj3.token_load("token6.json")
+        print obj3
+        self.assertEqual(obj, obj3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
this test will fail. obj and obj3 are two instances must be NotEqual.
token_load return value not received by any left-value.

